### PR TITLE
fix bug 853660 - Don't allow index.php access

### DIFF
--- a/themes/Hacks2010/index.php
+++ b/themes/Hacks2010/index.php
@@ -1,4 +1,10 @@
-<?php get_header();
+<?php 
+// Don't allow direct access to the theme
+if(!function_exists('get_header')) {
+  exit('Direct template access is not allowed');
+}
+
+get_header();
 
 // Fetch these IDs now because we'll be using them a lot.
 $demo_id = get_cat_ID('Demo');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=853660

That address is being hit because it's a dir default file.  This doesn't prevent direct access to all theme files though;  that would probably be done with .htaccess, which an Ops member maybe better at.
