### PR TITLE
fix bug 864724 - Allow wp-admin to use index.php while still blocking direct hits to index.php

### DIFF
--- a/themes/Hacks2013/functions.php
+++ b/themes/Hacks2013/functions.php
@@ -301,7 +301,7 @@ function is_comments_paged_url() {
 * The field has an innucuous name -- 'age' in this case -- likely to be autofilled by a robot.
 */
 function fc_honeypot( array $data ){
-  if( !isset($_POST['comment'])) { die("No Direct Access"); }  // Make sure the form has actually been submitted
+  if( !isset($_POST['comment']) && !isset($_POST['content'])) { die("No Direct Access"); }  // Make sure the form has actually been submitted
 
   if($_POST['age']) {  // If the Honeypot field has been filled in
     $message = _e('Sorry, you appear to be a spamming robot because you filled in the hidden spam trap field. To show you are not a spammer, submit your comment again and leave the field blank.', 'mozhacks');

--- a/themes/Hacks2013/index.php
+++ b/themes/Hacks2013/index.php
@@ -1,6 +1,6 @@
 <?php 
 // Don't allow direct access to the theme
-if(!function_exists('get_header')) {
+if(!defined('DB_NAME')) {
   exit('Direct template access is not allowed');
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=864724

To test:
1.  Hit /wp-content/themes/Hacks2013/index.php -- should die
2.  Go into an article with comments, trash the comment, and it should work.
