### PR TITLE
added update_info() to update.py script

### DIFF
--- a/scripts/update.py
+++ b/scripts/update.py
@@ -39,6 +39,13 @@ def deploy_app(ctx):
 def pre_update(ctx, ref=settings.UPDATE_REF):
     """Update code to pick up changes to this file."""
     update_code(ref)
+    update_info()
+
+
+@task
+def update_info(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("date > last_deploy.txt")
 
 
 @task


### PR DESCRIPTION
this should allow us to deploy the same refspec through chief. more details about why this is required can be found in comment 14 of bug 876844.
