### PR TITLE
fix #20 - add trackEvent for social share click

### DIFF
--- a/themes/Hacks2013/functions.php
+++ b/themes/Hacks2013/functions.php
@@ -236,6 +236,13 @@ function mozhacks_load_scripts() {
   if ( is_singular() && get_option('mozhacks_share_posts') && !is_page(array('home','about','demos','articles')) ) {
     wp_enqueue_script( 'socialshare' );
   }
+
+  // Register and load socialshare tracking script with jquery & socialshare
+  // dependencies
+  wp_register_script( 'socialtrack', get_template_directory_uri() . '/js/socialtrack.js', array('jquery', 'socialshare'));
+  if ( is_singular() && get_option('mozhacks_share_posts') && !is_page(array('home','about','demos','articles')) ) {
+    wp_enqueue_script( 'socialtrack', get_template_directory_uri() . '/js/socialtrack.js' );
+  }
 }
 add_action( 'wp_enqueue_scripts', 'mozhacks_load_scripts' );
 

--- a/themes/Hacks2013/js/socialtrack.js
+++ b/themes/Hacks2013/js/socialtrack.js
@@ -1,0 +1,8 @@
+jQuery(document).ready(function(){
+  var ga = window._gaq || [];
+  jQuery('.share').click(function(){
+    ga.push(['_trackEvent',
+      'socialshare',
+      'click']);
+  });
+});


### PR DESCRIPTION
Can't easily track _which_ social button is clicked because the iframes receive the mouse events. https://github.com/mozilla/SocialShare/issues/32 might help with that, but this is a start.
