### PR TITLE
Removing hyperlink to prevent redirection

### DIFF
--- a/themes/Hacks2013/header.php
+++ b/themes/Hacks2013/header.php
@@ -106,7 +106,7 @@
         <li <?php if ( is_page('about') ) {?>class="selected"<?php } ?>><a href="<?php echo get_permalink(get_page_by_path('about')->ID); ?>">About</a></li>
       </ul>
     </nav>
-    <a href="https://www.mozilla.org/" id="tabzilla">Mozilla</a>
+    <a href="#" id="tabzilla">Mozilla</a>
   </header><!-- /#branding -->
 
   <div id="content">


### PR DESCRIPTION
Right Now, If we click the tabzilla link, it redirects to the https://www.mozilla.org/. But its suppose to show the falldown tab. Therefore removing the link makes it a toggle for slidedown.
